### PR TITLE
API improvement

### DIFF
--- a/merry.py
+++ b/merry.py
@@ -85,18 +85,18 @@ class Merry(object):
 
                     except_start(handler, e)
                     # invoke handler
-                    ret = await _wrap_async(self.__except[handler])()
+                    ret = await _wrap_async(self.__except[handler])(*args, **kwargs)
                     except_end(handler, e)
 
                     return ret
                 else:
                     # if we have an else handler, call it now
                     if self.__else is not None:
-                        return await _wrap_async(self.__else)()
+                        return await _wrap_async(self.__else)(*args, **kwargs)
                 finally:
                     # if we have a finally handler, call it now
                     if self.__finally is not None:
-                        alt_ret = await _wrap_async(self.__finally)()
+                        alt_ret = await _wrap_async(self.__finally)(*args, **kwargs)
                         if alt_ret is not None:
                             ret = alt_ret
                         return ret
@@ -128,18 +128,18 @@ class Merry(object):
 
                     except_start(handler, e)
                     # invoke handler
-                    ret = self.__except[handler]()
+                    ret = self.__except[handler](*args, **kwargs)
                     except_end(handler, e)
 
                     return ret
                 else:
                     # if we have an else handler, call it now
                     if self.__else is not None:
-                        return self.__else()
+                        return self.__else(*args, **kwargs)
                 finally:
                     # if we have a finally handler, call it now
                     if self.__finally is not None:
-                        alt_ret = self.__finally()
+                        alt_ret = self.__finally(*args, **kwargs)
                         if alt_ret is not None:
                             ret = alt_ret
                         return ret

--- a/merry.py
+++ b/merry.py
@@ -50,12 +50,12 @@ class Merry(object):
         def except_start(handler, e):
             alias = self.__as[handler]
             if alias is not None:
-                setattr(self.g, alias, e)
+                setattr(self.__g, alias, e)
 
         def except_end(handler, e):
             alias = self.__as[handler]
-            if alias is not None and hasattr(self.g, alias):
-                delattr(self.g, alias)
+            if alias is not None and hasattr(self.__g, alias):
+                delattr(self.__g, alias)
 
         def get_handler_for(e):
             # find the best handler for this exception
@@ -191,7 +191,7 @@ class Merry(object):
         if self.__g is not None:
             return getattr(self.__g, key)
         raise RuntimeError(
-            "context can only be accessed inside error handling clause")
+            "context is only accessible within error handling clauses")
 
     def __setattr__(self, key, value):
         if key[:6] == "_Merry" and key[6:] in self.__slots__:
@@ -200,7 +200,7 @@ class Merry(object):
             return setattr(self.__g, key, value)
         else:
             raise RuntimeError(
-                "context can only be accessed inside error handling clause")
+                "context is only accessible within error handling clauses")
 
     def __delattr__(self, key):
         if not hasattr(self, key):
@@ -208,4 +208,4 @@ class Merry(object):
                 delattr(self.__g, key)
             else:
                 raise RuntimeError(
-                    "context can only be accessed inside error handling clause")
+                    "context is only accessible within error handling clauses")

--- a/merry.py
+++ b/merry.py
@@ -203,7 +203,7 @@ class Merry(object):
                 "context is only accessible within error handling clauses")
 
     def __delattr__(self, key):
-        if not hasattr(self, key):
+        if key[:6] != "_Merry" or key[6:] not in self.__slots__:
             if self.__g is not None:
                 delattr(self.__g, key)
             else:

--- a/merry.py
+++ b/merry.py
@@ -189,13 +189,16 @@ class Merry(object):
 
     @property
     def g(self):
+        if self.__g is None:
+            raise RuntimeError(
+                "context can only be accessed inside error handling clause")
         return self.__g
 
     def __getattr__(self, key):
         if self.__g is not None:
             return getattr(self.__g, key)
         raise RuntimeError(
-            "context can only be accessed during error handling")
+            "context can only be accessed inside error handling clause")
 
     def __setattr__(self, key, value):
         if key[:6] == "_Merry" and key[6:] in self.__slots__:
@@ -204,7 +207,7 @@ class Merry(object):
             return setattr(self.__g, key, value)
         else:
             raise RuntimeError(
-                "context can only be accessed during error handling")
+                "context can only be accessed inside error handling clause")
 
     def __delattr__(self, key):
         if not hasattr(self, key):
@@ -212,4 +215,4 @@ class Merry(object):
                 delattr(self.__g, key)
             else:
                 raise RuntimeError(
-                    "context can only be accessed during error handling")
+                    "context can only be accessed inside error handling clause")

--- a/merry.py
+++ b/merry.py
@@ -187,13 +187,6 @@ class Merry(object):
 
     # namespace accessors
 
-    @property
-    def g(self):
-        if self.__g is None:
-            raise RuntimeError(
-                "context can only be accessed inside error handling clause")
-        return self.__g
-
     def __getattr__(self, key):
         if self.__g is not None:
             return getattr(self.__g, key)

--- a/merry.py
+++ b/merry.py
@@ -176,17 +176,24 @@ class Merry(object):
     # namespace accessors
 
     def __getattr__(self, key):
-        return getattr(self.g, key)
+        if self.g is not None:
+            return getattr(self.g, key)
+        raise RuntimeError(
+            "context can only be accessed during error handling")
 
     def __setattr__(self, key, value):
         if hasattr(self, key):
-            super().__setattr__(key, value)
+            return super().__setattr__(key, value)
+        elif self.g is not None:
+            return setattr(self.g, key, value)
         else:
-            setattr(self.g, key, value)
+            raise RuntimeError(
+                "context can only be accessed during error handling")
 
     def __delattr__(self, key):
         if not hasattr(self, key):
-            delattr(self.g, key)
-
-    def __dir__(self):
-        return dir(self.g)
+            if self.g is not None:
+                delattr(self.g, key)
+            else:
+                raise RuntimeError(
+                    "context can only be accessed during error handling")

--- a/merry.py
+++ b/merry.py
@@ -17,7 +17,7 @@ class _Namespace:
 class Merry(object):
     def __init__(self, logger_name='merry', debug=False):
         self.__logger = logging.getLogger(logger_name)
-        self.__g = _Namespace()
+        self.g = _Namespace()
         self.__debug = debug
         self.__except = {}
         self.__force_debug = []
@@ -98,3 +98,21 @@ class Merry(object):
     def _finally(self, f):
         self.__finally_ = f
         return f
+
+    # namespace accessors
+
+    def __getattr__(self, key):
+        return getattr(self.g, key)
+
+    def __setattr__(self, key, value):
+        if hasattr(self, key):
+            super().__setattr__(key, value)
+        else:
+            setattr(self.g, key, value)
+
+    def __delattr__(self, key):
+        if not hasattr(self, key):
+            delattr(self.g, key)
+
+    def __dir__(self):
+        return dir(self.g)

--- a/merry.py
+++ b/merry.py
@@ -1,6 +1,6 @@
-from functools import wraps
 import inspect
 import logging
+from functools import wraps
 
 getargspec = None
 if getattr(inspect, 'getfullargspec', None):
@@ -16,14 +16,14 @@ class _Namespace:
 
 class Merry(object):
     def __init__(self, logger_name='merry', debug=False):
-        self.logger = logging.getLogger(logger_name)
-        self.g = _Namespace()
-        self.debug = debug
-        self.except_ = {}
-        self.force_debug = []
-        self.force_handle = []
-        self.else_ = None
-        self.finally_ = None
+        self.__logger = logging.getLogger(logger_name)
+        self.__g = _Namespace()
+        self.__debug = debug
+        self.__except = {}
+        self.__force_debug = []
+        self.__force_handle = []
+        self.__else = None
+        self.__finally = None
 
     def _try(self, f):
         @wraps(f)
@@ -40,7 +40,7 @@ class Merry(object):
             except Exception as e:
                 # find the best handler for this exception
                 handler = None
-                for c in self.except_.keys():
+                for c in self.__except.keys():
                     if isinstance(e, c):
                         if handler is None or issubclass(c, handler):
                             handler = c
@@ -50,30 +50,30 @@ class Merry(object):
                     raise e
 
                 # log exception
-                self.logger.exception('[merry] Exception caught')
+                self.__logger.exception('[merry] Exception caught')
 
                 # if in debug mode, then bubble up to let a debugger handle
-                debug = self.debug
-                if handler in self.force_debug:
+                debug = self.__debug
+                if handler in self.__force_debug:
                     debug = True
-                elif handler in self.force_handle:
+                elif handler in self.__force_handle:
                     debug = False
                 if debug:
                     raise e
 
                 # invoke handler
-                if len(getargspec(self.except_[handler])[0]) == 0:
-                    return self.except_[handler]()
+                if len(getargspec(self.__except[handler])[0]) == 0:
+                    return self.__except[handler]()
                 else:
-                    return self.except_[handler](e)
+                    return self.__except[handler](e)
             else:
                 # if we have an else handler, call it now
-                if self.else_ is not None:
-                    return self.else_()
+                if self.__else_ is not None:
+                    return self.__else_()
             finally:
                 # if we have a finally handler, call it now
-                if self.finally_ is not None:
-                    alt_ret = self.finally_()
+                if self.__finally_ is not None:
+                    alt_ret = self.__finally_()
                     if alt_ret is not None:
                         ret = alt_ret
                     return ret
@@ -82,19 +82,19 @@ class Merry(object):
     def _except(self, *args, **kwargs):
         def decorator(f):
             for e in args:
-                self.except_[e] = f
+                self.__except[e] = f
             d = kwargs.get('debug', None)
             if d:
-                self.force_debug.append(e)
+                self.__force_debug.append(e)
             elif d is not None:
-                self.force_handle.append(e)
+                self.__force_handle.append(e)
             return f
         return decorator
 
     def _else(self, f):
-        self.else_ = f
+        self.__else_ = f
         return f
 
     def _finally(self, f):
-        self.finally_ = f
+        self.__finally_ = f
         return f

--- a/merry.py
+++ b/merry.py
@@ -14,6 +14,15 @@ class _Namespace:
     pass
 
 
+def _wrap_async(fn):
+    async def _inner(*args, **kwargs):
+        if inspect.iscoroutinefunction(fn):
+            return await fn(*args, **kwargs)
+        else:
+            return fn(*args, **kwargs)
+    return _inner
+
+
 class Merry(object):
     def __init__(self, logger_name='merry', debug=False):
         self.__logger = logging.getLogger(logger_name)
@@ -26,58 +35,106 @@ class Merry(object):
         self.__finally = None
 
     def _try(self, f):
-        @wraps(f)
-        def wrapper(*args, **kwargs):
-            ret = None
-            try:
-                ret = f(*args, **kwargs)
+        if inspect.iscoroutinefunction(f):
+            @wraps(f)
+            async def async_wrapper(*args, **kwargs):
+                ret = None
+                try:
+                    ret = await f(*args, **kwargs)
 
-                # note that if the function returned something, the else clause
-                # will be skipped. This is a similar behavior to a normal
-                # try/except/else block.
-                if ret is not None:
-                    return ret
-            except Exception as e:
-                # find the best handler for this exception
-                handler = None
-                for c in self.__except.keys():
-                    if isinstance(e, c):
-                        if handler is None or issubclass(c, handler):
-                            handler = c
+                    # note that if the function returned something, the else clause
+                    # will be skipped. This is a similar behavior to a normal
+                    # try/except/else block.
+                    if ret is not None:
+                        return ret
+                except Exception as e:
+                    # find the best handler for this exception
+                    handler = None
+                    for c in self.__except.keys():
+                        if isinstance(e, c):
+                            if handler is None or issubclass(c, handler):
+                                handler = c
 
-                # if we don't have any handler, we let the exception bubble up
-                if handler is None:
-                    raise e
+                    # if we don't have any handler, we let the exception bubble up
+                    if handler is None:
+                        raise e
 
-                # log exception
-                self.__logger.exception('[merry] Exception caught')
+                    # log exception
+                    self.__logger.exception('[merry] Exception caught')
 
-                # if in debug mode, then bubble up to let a debugger handle
-                debug = self.__debug
-                if handler in self.__force_debug:
-                    debug = True
-                elif handler in self.__force_handle:
-                    debug = False
-                if debug:
-                    raise e
+                    # if in debug mode, then bubble up to let a debugger handle
+                    debug = self.__debug
+                    if handler in self.__force_debug:
+                        debug = True
+                    elif handler in self.__force_handle:
+                        debug = False
+                    if debug:
+                        raise e
 
-                # invoke handler
-                if len(getargspec(self.__except[handler])[0]) == 0:
+                    # invoke handler
+                    return await _wrap_async(self.__except[handler])()
+                else:
+                    # if we have an else handler, call it now
+                    if self.__else is not None:
+                        return await _wrap_async(self.__else)()
+                finally:
+                    # if we have a finally handler, call it now
+                    if self.__finally is not None:
+                        alt_ret = await _wrap_async(self.__finally)()
+                        if alt_ret is not None:
+                            ret = alt_ret
+                        return ret
+            return async_wrapper
+        else:
+            @wraps(f)
+            def wrapper(*args, **kwargs):
+                ret = None
+                try:
+                    ret = f(*args, **kwargs)
+
+                    # note that if the function returned something, the else clause
+                    # will be skipped. This is a similar behavior to a normal
+                    # try/except/else block.
+                    if ret is not None:
+                        return ret
+                except Exception as e:
+                    # find the best handler for this exception
+                    handler = None
+                    for c in self.__except.keys():
+                        if isinstance(e, c):
+                            if handler is None or issubclass(c, handler):
+                                handler = c
+
+                    # if we don't have any handler, we let the exception bubble up
+                    if handler is None:
+                        raise e
+
+                    # log exception
+                    self.__logger.exception('[merry] Exception caught')
+
+                    # if in debug mode, then bubble up to let a debugger handle
+                    debug = self.__debug
+                    if handler in self.__force_debug:
+                        debug = True
+                    elif handler in self.__force_handle:
+                        debug = False
+                    if debug:
+                        raise e
+
+                    # invoke handler
                     return self.__except[handler]()
                 else:
-                    return self.__except[handler](e)
-            else:
-                # if we have an else handler, call it now
-                if self.__else_ is not None:
-                    return self.__else_()
-            finally:
-                # if we have a finally handler, call it now
-                if self.__finally_ is not None:
-                    alt_ret = self.__finally_()
-                    if alt_ret is not None:
-                        ret = alt_ret
-                    return ret
-        return wrapper
+                    # if we have an else handler, call it now
+                    if self.__else is not None:
+                        return self.__else()
+                finally:
+                    # if we have a finally handler, call it now
+                    if self.__finally is not None:
+                        alt_ret = self.__finally()
+                        if alt_ret is not None:
+                            ret = alt_ret
+                        return ret
+            return wrapper
 
     def _except(self, *args, **kwargs):
         def decorator(f):
@@ -92,11 +149,11 @@ class Merry(object):
         return decorator
 
     def _else(self, f):
-        self.__else_ = f
+        self.__else = f
         return f
 
     def _finally(self, f):
-        self.__finally_ = f
+        self.__finally = f
         return f
 
     # namespace accessors

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,8 @@ setup(
     platforms='any',
     install_requires=[],
     tests_require=[
-        'coverage'
+        'coverage',
+        'aiounittest'
     ],
     test_suite='test_merry',
     classifiers=[

--- a/test_merry.py
+++ b/test_merry.py
@@ -1,19 +1,20 @@
+from merry import Merry
 import logging
+import asyncio
 try:
     from StringIO import StringIO
 except ImportError:
     from io import StringIO
 import unittest
+import aiounittest
 
 import coverage
 
 cov = coverage.coverage()
 cov.start()
 
-from merry import Merry
 
-
-class TestMerry(unittest.TestCase):
+class TestMerry(aiounittest.AsyncTestCase):
     @classmethod
     def setUpClass(cls):
         pass
@@ -369,6 +370,278 @@ class TestMerry(unittest.TestCase):
         f()
         self.assertIn('Traceback', stream.getvalue())
         self.assertIn('ZeroDivisionError: ', stream.getvalue())
+
+    def test_same_signature_except_finally(self):
+        m = Merry()
+        foo = object()
+        bar = object()
+
+        f_args = None
+        f_kwargs = None
+
+        except_args = None
+        except_kwargs = None
+
+        finally_args = None
+        finally_kwargs = None
+
+        @m._except(Exception)
+        def catch_all(*args, **kwargs):
+            nonlocal except_args, except_kwargs
+            except_args = args
+            except_kwargs = kwargs
+
+        @m._finally
+        def finally_clause(*args, **kwargs):
+            nonlocal finally_args, finally_kwargs
+            finally_args = args
+            finally_kwargs = kwargs
+
+        @m._try
+        def f(*args, **kwargs):
+            nonlocal f_args, f_kwargs
+            f_args = args
+            f_kwargs = kwargs
+            1/0
+
+        f(foo, value=bar)
+        self.assertSequenceEqual(f_args, [foo])
+        self.assertIs(f_args[0], foo)
+        self.assertSequenceEqual(except_args, [foo])
+        self.assertIs(except_args[0], foo)
+        self.assertSequenceEqual(finally_args, [foo])
+        self.assertIs(finally_args[0], foo)
+        self.assertDictEqual(f_kwargs, {'value': bar})
+        self.assertIs(f_kwargs['value'], bar)
+        self.assertDictEqual(except_kwargs, {'value': bar})
+        self.assertIs(except_kwargs['value'], bar)
+        self.assertDictEqual(finally_kwargs, {'value': bar})
+        self.assertIs(finally_kwargs['value'], bar)
+
+    def test_same_signature_else_finally(self):
+        m = Merry()
+        bar = object()
+        foo = object()
+
+        f_args = None
+        f_kwargs = None
+
+        else_args = None
+        else_kwargs = None
+
+        finally_args = None
+        finally_kwargs = None
+
+        @m._else
+        def else_clause(*args, **kwargs):
+            nonlocal else_args, else_kwargs
+            else_args = args
+            else_kwargs = kwargs
+
+        @m._finally
+        def finally_clause(*args, **kwargs):
+            nonlocal finally_args, finally_kwargs
+            finally_args = args
+            finally_kwargs = kwargs
+
+        @m._try
+        def f(*args, **kwargs):
+            nonlocal f_args, f_kwargs
+            f_args = args
+            f_kwargs = kwargs
+
+        f(foo, value=bar)
+        self.assertSequenceEqual(f_args, [foo])
+        self.assertIs(f_args[0], foo)
+        self.assertSequenceEqual(else_args, [foo])
+        self.assertIs(else_args[0], foo)
+        self.assertSequenceEqual(finally_args, [foo])
+        self.assertIs(finally_args[0], foo)
+        self.assertDictEqual(f_kwargs, {'value': bar})
+        self.assertIs(f_kwargs['value'], bar)
+        self.assertDictEqual(else_kwargs, {'value': bar})
+        self.assertIs(else_kwargs['value'], bar)
+        self.assertDictEqual(finally_kwargs, {'value': bar})
+        self.assertIs(finally_kwargs['value'], bar)
+
+    def test_context_getattr(self):
+        m = Merry()
+        expected_obj = object()
+        except_obj = None
+        finally_obj = None
+        outside_obj1 = None
+        outside_obj2 = None
+        except_called = False
+        finally_called = False
+
+        def access_outside1():
+            nonlocal outside_obj1
+            outside_obj1 = m.o
+
+        def access_outside2():
+            nonlocal outside_obj1
+            outside_obj1 = m.o
+
+        @m._except(Exception)
+        def catch_all(o):
+            nonlocal except_obj, except_called
+            # test getter
+            except_obj = m.o
+            except_called = True
+
+        @m._finally
+        def finally_clause(o):
+            nonlocal finally_obj, finally_called
+            finally_obj = m.o
+            finally_called = True
+
+        @m._try
+        def f(o):
+            m.o = o
+            1/0
+
+        self.assertRaises(RuntimeError, access_outside1)
+        self.assertIsNot(outside_obj1, expected_obj)
+
+        f(expected_obj)
+
+        self.assertTrue(except_called)
+        self.assertTrue(finally_called)
+
+        self.assertIs(except_obj, expected_obj)
+        self.assertIs(finally_obj, expected_obj)
+
+        self.assertRaises(RuntimeError, access_outside2)
+        self.assertIsNot(outside_obj2, expected_obj)
+
+    def test_context_delattr(self):
+        m = Merry()
+        expected_obj1 = object()
+        expected_obj2 = object()
+        except_has_attr1 = False
+        except_has_attr2 = False
+        except_called = False
+
+        def access_outside():
+            del m.o2
+
+        @m._except(Exception)
+        def catch_all(o1, o2):
+            nonlocal except_called, except_has_attr1, except_has_attr2
+            except_has_attr1 = hasattr(m, "o1")
+            del m.o1
+            except_has_attr2 = hasattr(m, "o1")
+            except_called = True
+
+        @m._try
+        def f(o1, o2):
+            m.o1 = o1
+            m.o2 = o2
+            1/0
+
+
+        f(expected_obj1, expected_obj2)
+
+        self.assertTrue(except_called)
+        self.assertTrue(except_has_attr1)
+        self.assertFalse(except_has_attr2)
+
+        self.assertRaises(RuntimeError, access_outside)
+
+    def test_context_setattr(self):
+        pass
+    
+    async def test_except_async(self):
+        m = Merry()
+        except_called = False
+
+        @m._except(ZeroDivisionError)
+        async def zerodiv():
+            nonlocal except_called
+            await asyncio.sleep(0)
+            except_called = True
+
+        @m._try
+        async def f():
+            1/0
+
+        await f()
+        self.assertTrue(except_called)
+
+    async def test_except_finally_async(self):
+        m = Merry()
+        except_called = False
+        finally_called = False
+
+        @m._except(ZeroDivisionError)
+        async def zerodiv():
+            nonlocal except_called
+            await asyncio.sleep(0)
+            except_called = True
+
+        @m._finally
+        async def finally_clause():
+            nonlocal finally_called
+            await asyncio.sleep(0)
+            finally_called = True
+
+        @m._try
+        async def f():
+            1/0
+
+        await f()
+        self.assertTrue(except_called)
+        self.assertTrue(finally_called)
+    
+    async def test_else_async(self):
+        m = Merry()
+        except_called = False
+        else_called = False
+
+        @m._except(ZeroDivisionError)
+        async def zerodiv():
+            nonlocal except_called
+            await asyncio.sleep(0)
+            except_called = True
+
+        @m._else
+        async def else_clause():
+            nonlocal else_called
+            await asyncio.sleep(0)
+            else_called = True
+
+        @m._try
+        async def f():
+            pass
+
+        await f()
+        self.assertFalse(except_called)
+        self.assertTrue(else_called)
+
+    async def test_async_try_sync_handlers(self):
+        m = Merry()
+        except_called = False
+        finally_called = False
+
+        @m._except(ZeroDivisionError, _as="e")
+        def zerodiv():
+            nonlocal except_called
+            self.assertIsInstance(m.e, ZeroDivisionError)
+            except_called = True
+        
+        @m._finally
+        def finally_clause():
+            nonlocal finally_called
+            finally_called = True
+
+        @m._try
+        async def f():
+            await asyncio.sleep(0)
+            1/0
+
+        await f()
+        self.assertTrue(except_called)
+        self.assertTrue(finally_called)
 
 
 if __name__ == '__main__':

--- a/test_merry.py
+++ b/test_merry.py
@@ -200,7 +200,7 @@ class TestMerry(aiounittest.AsyncTestCase):
         def f():
             return 'foo'
 
-        @m._except
+        @m._except(Exception)
         def except_clause():
             return 'baz'
 
@@ -371,6 +371,21 @@ class TestMerry(aiounittest.AsyncTestCase):
         self.assertIn('Traceback', stream.getvalue())
         self.assertIn('ZeroDivisionError: ', stream.getvalue())
 
+    def test_no_else_without_except(self):
+        m = Merry()
+        else_called = False
+
+        @m._try
+        def f():
+            1/0
+        
+        @m._else
+        def else_clause():
+            nonlocal else_called
+            else_called = True
+        
+        self.assertRaises(RuntimeError, f)
+
     def test_same_signature_except_finally(self):
         m = Merry()
         foo = object()
@@ -437,6 +452,10 @@ class TestMerry(aiounittest.AsyncTestCase):
             nonlocal else_args, else_kwargs
             else_args = args
             else_kwargs = kwargs
+        
+        @m._except(Exception)
+        def except_clause(*args, **kwargs):
+            pass
 
         @m._finally
         def finally_clause(*args, **kwargs):


### PR DESCRIPTION
## Changes

- Provide shortcut accessors on the Merry instance to access the namespace.
- Support async error handling suite.
- Improve `_except` API. Now it can directly be used as a deco to register a handler for BaseException. Add a new kwarg "_as" to create an accessor on the namespace to access the caught error instance.
- Improve `_else`, which should come with any `_except`s or a RuntimeError is raised.
- Make `_try`, `_except`, `_else` and `_finally` share the same signature (bypass the same args, kwargs to all of them).
- Clean up `g` namespace after each error handling for less possibilities to memory leak.

All error handling suites are made to share the same signature therefore they can be methods of the same class, instance level context should rather be a member data than a Merry.Namespace member.

This is useful for example in the class-based Namespace of python-socketio.

```py
class MyClass:
    # static member
    m = Merry()

    @m._try
    def method_a(self):
        pass

    @m._except  # all BaseException
    def handle_all_error(self):
        pass
```

Merry.Namespace should only be accessible inside error handling clauses to avoid memory leak.

Please also take a look at new test cases for other examples of the new changes.
Thanks!